### PR TITLE
Blanks allowed in dates for 'loose' and 'fast'; some time zone cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -246,7 +246,10 @@ Four methods of parsing the label are provided.
   * It allows slashes in file names and in text strings that are not quoted (e.g., `N/A`).
   * It allows the value of `END_OBJECT` and `END_GROUP` to be absent, as long as they are
     still properly paired with associated `OBJECT` and `GROUP` keywords.
-  * It allows time zone expressions (where were disallowed after the PDS2 standard).
+  * It allows time zone expressions, which were disallowed starting in Version 4 of the
+    standards.
+  * It allows blanks where leading zeros belong in dates and times, e.g., "`2026- 7 - 4`"
+    instead of "`2026-07-04`" and "`12: 3: 4`" instead of "`12:03:04`".
   * Commas can be missing between the elements of a sequence or set.
   * The final line terminator after `END` can be missing from a detached label.
 

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@
 ![GitHub License](https://img.shields.io/github/license/SETI/rms-pdsparser)
 [![Number of GitHub stars](https://img.shields.io/github/stars/SETI/rms-pdsparser)](https://github.com/SETI/rms-pdsparser/stargazers)
 ![GitHub forks](https://img.shields.io/github/forks/SETI/rms-pdsparser)
+[![DOI](https://zenodo.org/badge/709386326.svg)](https://zenodo.org/badge/latestdoi/709386326)
 
 # Introduction
 

--- a/pdsparser/_PDS3_GRAMMAR.py
+++ b/pdsparser/_PDS3_GRAMMAR.py
@@ -230,17 +230,22 @@ _ZERO_59 = Word('012345', nums, exact=2)
 _HMS_TIME0 = (_ZERO_23 + Suppress(':') + _ZERO_59
               + Optional(Suppress(':')
                          + Combine(_ZERO_59 + Optional('.' + Optional(_UNSIGNED_INT)))))
-_HMS_TIME1 = _HMS_TIME0.copy()
-_HMS_TIME = _HMS_TIME0 | (Suppress('"') + _HMS_TIME0 + Suppress('"'))
-_HMS_TIME.set_name('_HMS_TIME')
+_UTC_TIME0 = _HMS_TIME0.copy() + Suppress(Literal('Z'))
 
-_UTC_TIME0 = (_ZERO_23 + Suppress(':') + _ZERO_59
-              + Optional(Suppress(':')
-                         + Combine(_ZERO_59 + Optional('.' + Optional(_UNSIGNED_INT))))
-              + Suppress(Literal('Z')))
-_UTC_TIME1 = _UTC_TIME0.copy()
-_UTC_TIME = _UTC_TIME0 | (Suppress('"') + _UTC_TIME0 + Suppress('"'))
-_UTC_TIME.set_name('_UTC_TIME')
+_ALT_ZERO_23 = Word(' 01', nums, exact=2) | Word('2', '0123', exact=2)
+_ALT_ZERO_23_SHORT = _ALT_ZERO_23 | Word(nums, exact=1)
+# ^ The "_SHORT" version is needed for a standalone time; disallowed for a date-time.
+_ALT_ZERO_59 = Word(' 012345', nums, exact=2)
+_ALT_HMS_TIME0 = (_ALT_ZERO_23 + Suppress(':') + _ALT_ZERO_59
+                  + Optional(Suppress(':')
+                             + Combine(_ALT_ZERO_59
+                             + Optional('.' + Optional(_UNSIGNED_INT)))))
+_ALT_HMS_TIME0_SHORT = (_ALT_ZERO_23_SHORT + Suppress(':') + _ALT_ZERO_59
+                        + Optional(Suppress(':')
+                                   + Combine(_ALT_ZERO_59
+                                   + Optional('.' + Optional(_UNSIGNED_INT)))))
+_ALT_UTC_TIME0 = _ALT_HMS_TIME0.copy() + Suppress(Literal('Z'))
+_ALT_UTC_TIME0_SHORT = _ALT_HMS_TIME0_SHORT.copy() + Suppress(Literal('Z'))
 
 class _SimpleTime(_Time):
     """Time without time zone, with optional "Z"."""
@@ -288,7 +293,6 @@ class _HmsTime(_SimpleTime):
     """A time of day, excluding a time zone."""
 
     type_ = 'local_time'
-    grammar = _HMS_TIME
 
     def __init__(self, s, loc, tokens):
         _SimpleTime.__init__(self, s, loc, tokens)
@@ -298,68 +302,94 @@ class _UtcTime(_SimpleTime):
     """A time of day with "Z" suffix."""
 
     type_ = 'utc_time'
-    grammar = _UTC_TIME
 
     def __init__(self, s, loc, tokens):
         _SimpleTime.__init__(self, s, loc, tokens)
         self.z = 'Z'
 
-_HMS_TIME.set_parse_action(_HmsTime)
-_UTC_TIME.set_parse_action(_UtcTime)
+_HMS_TIME0.set_parse_action(_HmsTime)
+_UTC_TIME0.set_parse_action(_UtcTime)
+_ALT_HMS_TIME0.set_parse_action(_HmsTime)
+_ALT_UTC_TIME0.set_parse_action(_UtcTime)
+_ALT_HMS_TIME0_SHORT.set_parse_action(_HmsTime)
+_ALT_UTC_TIME0_SHORT.set_parse_action(_UtcTime)
 
-_HMS_TIME1.set_parse_action(_HmsTime)   # parse action applied but no quotes allowed
-_UTC_TIME1.set_parse_action(_UtcTime)
+_HMS_TIME = _HMS_TIME0 | (Suppress('"') + _HMS_TIME0 + Suppress('"'))
+_HMS_TIME.set_name('_HMS_TIME')
+_HmsTime.grammar = _HMS_TIME
+
+_UTC_TIME = _UTC_TIME0 | (Suppress('"') + _UTC_TIME0 + Suppress('"'))
+_UTC_TIME.set_name('_UTC_TIME')
+_UtcTime.grammar = _UTC_TIME
+
+_ALT_HMS_TIME = (_ALT_HMS_TIME0 | _ALT_HMS_TIME0_SHORT
+                 | (Suppress('"') + _ALT_HMS_TIME0 + Suppress('"')))
+_ALT_HMS_TIME.set_name('_ALT_HMS_TIME')
+_HmsTime.alt_grammar = _ALT_HMS_TIME
+
+_ALT_UTC_TIME = (_ALT_UTC_TIME0 | _ALT_UTC_TIME0_SHORT
+                 | (Suppress('"') + _ALT_UTC_TIME0 + Suppress('"')))
+_ALT_UTC_TIME.set_name('_ALT_UTC_TIME')
+_UtcTime.alt_grammar = _ALT_UTC_TIME
 
 ##########################################################################################
 # _TimeZone
 ##########################################################################################
-_ALT_ZERO_23 = _ZERO_23 | Word(nums, max=1)
-_TIME_ZONE = Combine(_SIGN + _ALT_ZERO_23) + Optional(Suppress(':') + _ZERO_59)
+_TZ_HOUR = (one_of(['-12', '-11', '-10', '+10', '+11', '+12', '+13', '+14'])
+            | Combine(_SIGN + Word('0', nums, exact=2))
+            | Combine(_SIGN + Word(nums, exact=1)))
+_TZ_MINUTE = one_of([':00', ':15', ':30', ':45', ''])
+_TIME_ZONE = Combine(_TZ_HOUR + _TZ_MINUTE)
 _TIME_ZONE.set_name('_TIME_ZONE')
+
+_ALT_TZ_HOUR = (one_of(['-12', '-11', '-10', '+10', '+11', '+12', '+13', '+14'])
+                | Combine(_SIGN + Word(' 0', nums, exact=2))
+                | Combine(_SIGN + Word(nums, exact=1)))
+_ALT_TZ_MINUTE = one_of([':00', ':15', ':30', ':45', '', ': 0'])
+_ALT_TIME_ZONE = Combine(_ALT_TZ_HOUR + _ALT_TZ_MINUTE)
+_ALT_TIME_ZONE.set_name('_ALT_TIME_ZONE')
 
 class _TimeZone(_Item):
     """A time zone."""
 
     type_ = 'time_zone'
     grammar = _TIME_ZONE
+    alt_grammar = _ALT_TIME_ZONE
     suffixes = ('sec', 'fmt')
 
     def __init__(self, s, loc, tokens):
-        self.tokens = tokens
-        sign = -1 if tokens[0][0] == '-' else 1
-        hours = int(tokens[0])
-        minutes = 60 * hours + sign * (int(tokens[1]) if len(tokens) > 1 else 0)
-
-        self.sec = 60 * minutes
+        self.token = tokens[0]
+        sign = -1 if self.token[0] == '-' else 1
+        parts = self.token.partition(':')
+        hours = int(parts[0][1:])
+        minutes = int(parts[2]) if parts[2] else 0
+        self.sec = sign * (3600 * hours + 60 * minutes)
         self.value = dt.timezone(dt.timedelta(seconds=self.sec))
-        self.fmt = str(self)
+        if parts[2]:
+            self.fmt = '%s%02d:%02d' % ('-' if self.sec < 0 else '+', hours, minutes)
+        else:
+            self.fmt = '%s%02d' % ('-' if self.sec < 0 else '+', hours)
 
     @property
     def source(self):
-        return ':'.join(self.tokens)
+        return self.token
 
     def __str__(self):
-        if len(self.tokens) == 1:
-            return '%+03d:00' % int(self.tokens[0])
-        else:
-            sign = self.tokens[0][0]
-            hours = abs(int(self.tokens[0]))
-            return sign + '%02d' % hours + ':' + self.tokens[1]
+        return self.fmt
 
 _TIME_ZONE.set_parse_action(_TimeZone)
+_ALT_TIME_ZONE.set_parse_action(_TimeZone)
 
 ##########################################################################################
 # _ZonedTime
 ##########################################################################################
-_ZONED_TIME0 = _HMS_TIME1 + _TIME_ZONE
-_ZONED_TIME = _ZONED_TIME0 | (Suppress('"') + _ZONED_TIME0 + Suppress('"'))
-_ZONED_TIME.set_name('_ZONED_TIME')
+_ZONED_TIME0 = _HMS_TIME0 + _TIME_ZONE
+_ALT_ZONED_TIME0 = _ALT_HMS_TIME0 + _ALT_TIME_ZONE
 
 class _ZonedTime(_Time):
     """A time of day with a time zone."""
 
     type_ = 'zoned_time'
-    alt_grammar = _ZONED_TIME
     suffixes = ('sec', 'fmt')
 
     def __init__(self, s, loc, tokens):
@@ -379,18 +409,30 @@ class _ZonedTime(_Time):
     def __str__(self):
         return str(self.hms_time) + str(self.time_zone)
 
-_ZONED_TIME.set_parse_action(_ZonedTime)
+_ZONED_TIME0.set_parse_action(_ZonedTime)
+_ALT_ZONED_TIME0.set_parse_action(_ZonedTime)
 
+_ZONED_TIME = _ZONED_TIME0 | (Suppress('"') + _ZONED_TIME0 + Suppress('"'))
+_ZONED_TIME.set_name('_ZONED_TIME')
+_ZonedTime.grammar = _ZONED_TIME
+
+_ALT_ZONED_TIME = _ALT_ZONED_TIME0 | (Suppress('"') + _ALT_ZONED_TIME0 + Suppress('"'))
+_ALT_ZONED_TIME.set_name('_ALT_ZONED_TIME')
+_ZonedTime.alt_grammar = _ALT_ZONED_TIME
+
+# NOTE: time zones disabled for method="strict"
+# _TIME0 = _ZONED_TIME0 | _UTC_TIME0 | _HMS_TIME0
+_TIME0 = _UTC_TIME0 | _HMS_TIME0
+_ALT_TIME0 = _ALT_ZONED_TIME0 | _ALT_UTC_TIME0 | _ALT_HMS_TIME0
+
+# _TIME = _ZONED_TIME | _UTC_TIME | _HMS_TIME
 _TIME = _UTC_TIME | _HMS_TIME
 _TIME.set_name('_TIME')
 _Time.grammar = _TIME
 
-_ALT_TIME = _ZONED_TIME | _UTC_TIME | _HMS_TIME
+_ALT_TIME = _ALT_ZONED_TIME | _ALT_UTC_TIME | _ALT_HMS_TIME
 _ALT_TIME.set_name('_ALT_TIME')
 _Time.alt_grammar = _ALT_TIME
-
-_TIME1 = _UTC_TIME1 | _HMS_TIME1    # parse action applied but no quotes allowed
-_ALT_TIME1 = _ZONED_TIME | _UTC_TIME1 | _HMS_TIME1
 
 ##########################################################################################
 # _Date
@@ -403,16 +445,19 @@ _DOY = (Word('0123', nums, exact=3))
 _YMD_DATE = _YEAR + Suppress('-') + _MONTH + Suppress('-') + _DAY
 _YD_DATE = _YEAR + Suppress('-') + _DOY
 _DATE0 = _YMD_DATE | _YD_DATE
-_DATE1 = _DATE0.copy()
 
-_DATE = _DATE0 | (Suppress('"') + _DATE0 + Suppress('"'))
-_DATE.set_name('_DATE')
+_ALT_MONTH = _MONTH | Word(' ', '123456789', exact=2)
+_ALT_DAY = _DAY | Word(' ', '123456789', exact=2)
+_ALT_DOY = (_DOY | Word(' ', nums, exact=3)
+            | Combine(Literal('  ') + Word('123456789', exact=1)))
+_ALT_YMD_DATE = _YEAR + Suppress('-') + _ALT_MONTH + Suppress('-') + _ALT_DAY
+_ALT_YD_DATE = _YEAR + Suppress('-') + _ALT_DOY
+_ALT_DATE0 = _ALT_YMD_DATE | _ALT_YD_DATE
 
 class _Date(_Scalar):
     """A date as year, month and day or year and day-of-year."""
 
     type_ = 'date'
-    grammar = _DATE
     suffixes = ('day', 'fmt')
 
     def __init__(self, s, loc, tokens):
@@ -426,27 +471,28 @@ class _Date(_Scalar):
         self.fmt = str(self)
 
     def __str__(self):
-        return '-'.join(self.tokens)
+        return '-'.join(self.tokens).replace(' ', '0')
 
-_DATE.set_parse_action(_Date)
-_DATE1.set_parse_action(_Date)  # parse action applied but no quotes allowed
+_DATE0.set_parse_action(_Date)
+_ALT_DATE0.set_parse_action(_Date)
+
+_DATE = _DATE0 | (Suppress('"') + _DATE0 + Suppress('"'))
+_DATE.set_name('_DATE')
+_Date.grammar = _DATE
+
+_ALT_DATE = _ALT_DATE0 | (Suppress('"') + _ALT_DATE0 + Suppress('"'))
+_ALT_DATE.set_name('_ALT_DATE')
+_Date.alt_grammar = _ALT_DATE
 
 ##########################################################################################
 # _DateTime
 ##########################################################################################
-_DATE_TIME0 = _DATE1 + Suppress('T') + _TIME1
-_DATE_TIME = _DATE_TIME0 | (Suppress('"') + _DATE_TIME0 + Suppress('"'))
-_DATE_TIME.set_name('_DATE_TIME')
-
-_ALT_DATE_TIME0 = _DATE1 + Suppress('T') + _ALT_TIME1
-_ALT_DATE_TIME = _ALT_DATE_TIME0 | (Suppress('"') + _ALT_DATE_TIME0 + Suppress('"'))
-_ALT_DATE_TIME.set_name('_ALT_DATE_TIME')
+_DATE_TIME0 = _DATE0 + Suppress('T') + _TIME0
+_ALT_DATE_TIME0 = _ALT_DATE0 + Suppress('T') + _ALT_TIME0
 
 class _DateTime(_Scalar):
 
     type_ = 'date_time'
-    grammar = _DATE_TIME
-    alt_grammar = _ALT_DATE_TIME
     suffixes = ('day', 'sec', 'fmt')
 
     def __init__(self, s, loc, tokens):
@@ -471,8 +517,16 @@ class _DateTime(_Scalar):
     def __str__(self):
         return str(self.date) + 'T' + str(self.time)
 
-_DATE_TIME.set_parse_action(_DateTime)
-_ALT_DATE_TIME.set_parse_action(_DateTime)
+_DATE_TIME0.set_parse_action(_DateTime)
+_ALT_DATE_TIME0.set_parse_action(_DateTime)
+
+_DATE_TIME = _DATE_TIME0 | (Suppress('"') + _DATE_TIME0 + Suppress('"'))
+_DATE_TIME.set_name('_DATE_TIME')
+_DateTime.grammar = _DATE_TIME
+
+_ALT_DATE_TIME = _ALT_DATE_TIME0 | (Suppress('"') + _ALT_DATE_TIME0 + Suppress('"'))
+_ALT_DATE_TIME.set_name('_ALT_DATE_TIME')
+_DateTime.alt_grammar = _ALT_DATE_TIME
 
 ##########################################################################################
 # _Text
@@ -557,7 +611,7 @@ _SCALAR = _DATE_TIME | _DATE | _TIME | _NUMBER | _TEXT_VALUE    # Order counts!
 _SCALAR.set_name('_SCALAR')
 _Scalar.grammar = _SCALAR
 
-_ALT_SCALAR = _ALT_DATE_TIME | _DATE | _ALT_TIME | _NUMBER | _ALT_TEXT_VALUE
+_ALT_SCALAR = _ALT_DATE_TIME | _ALT_DATE | _ALT_TIME | _NUMBER | _ALT_TEXT_VALUE
 _ALT_SCALAR.set_name('_ALT_SCALAR')
 _Scalar.alt_grammar = _ALT_SCALAR
 

--- a/pdsparser/_PDS3_GRAMMAR.py
+++ b/pdsparser/_PDS3_GRAMMAR.py
@@ -384,7 +384,7 @@ _ALT_TIME_ZONE.set_parse_action(_TimeZone)
 # _ZonedTime
 ##########################################################################################
 _ZONED_TIME0 = _HMS_TIME0 + _TIME_ZONE
-_ALT_ZONED_TIME0 = _ALT_HMS_TIME0 + _ALT_TIME_ZONE
+_ALT_ZONED_TIME0 = _ALT_HMS_TIME0_SHORT + _ALT_TIME_ZONE
 
 class _ZonedTime(_Time):
     """A time of day with a time zone."""

--- a/pdsparser/_PDS3_GRAMMAR.py
+++ b/pdsparser/_PDS3_GRAMMAR.py
@@ -322,13 +322,11 @@ _UTC_TIME = _UTC_TIME0 | (Suppress('"') + _UTC_TIME0 + Suppress('"'))
 _UTC_TIME.set_name('_UTC_TIME')
 _UtcTime.grammar = _UTC_TIME
 
-_ALT_HMS_TIME = (_ALT_HMS_TIME0 | _ALT_HMS_TIME0_SHORT
-                 | (Suppress('"') + _ALT_HMS_TIME0 + Suppress('"')))
+_ALT_HMS_TIME = _ALT_HMS_TIME0_SHORT | (Suppress('"') + _ALT_HMS_TIME0 + Suppress('"'))
 _ALT_HMS_TIME.set_name('_ALT_HMS_TIME')
 _HmsTime.alt_grammar = _ALT_HMS_TIME
 
-_ALT_UTC_TIME = (_ALT_UTC_TIME0 | _ALT_UTC_TIME0_SHORT
-                 | (Suppress('"') + _ALT_UTC_TIME0 + Suppress('"')))
+_ALT_UTC_TIME = _ALT_UTC_TIME0_SHORT | (Suppress('"') + _ALT_UTC_TIME0 + Suppress('"'))
 _ALT_UTC_TIME.set_name('_ALT_UTC_TIME')
 _UtcTime.alt_grammar = _ALT_UTC_TIME
 
@@ -384,7 +382,8 @@ _ALT_TIME_ZONE.set_parse_action(_TimeZone)
 # _ZonedTime
 ##########################################################################################
 _ZONED_TIME0 = _HMS_TIME0 + _TIME_ZONE
-_ALT_ZONED_TIME0 = _ALT_HMS_TIME0_SHORT + _ALT_TIME_ZONE
+_ALT_ZONED_TIME0 = _ALT_HMS_TIME0 + _ALT_TIME_ZONE
+_ALT_ZONED_TIME0_SHORT = _ALT_HMS_TIME0_SHORT + _ALT_TIME_ZONE
 
 class _ZonedTime(_Time):
     """A time of day with a time zone."""
@@ -411,12 +410,14 @@ class _ZonedTime(_Time):
 
 _ZONED_TIME0.set_parse_action(_ZonedTime)
 _ALT_ZONED_TIME0.set_parse_action(_ZonedTime)
+_ALT_ZONED_TIME0_SHORT.set_parse_action(_ZonedTime)
 
 _ZONED_TIME = _ZONED_TIME0 | (Suppress('"') + _ZONED_TIME0 + Suppress('"'))
 _ZONED_TIME.set_name('_ZONED_TIME')
 _ZonedTime.grammar = _ZONED_TIME
 
-_ALT_ZONED_TIME = _ALT_ZONED_TIME0 | (Suppress('"') + _ALT_ZONED_TIME0 + Suppress('"'))
+_ALT_ZONED_TIME = (_ALT_ZONED_TIME0_SHORT
+                   | (Suppress('"') + _ALT_ZONED_TIME0 + Suppress('"')))
 _ALT_ZONED_TIME.set_name('_ALT_ZONED_TIME')
 _ZonedTime.alt_grammar = _ALT_ZONED_TIME
 

--- a/pdsparser/__init__.py
+++ b/pdsparser/__init__.py
@@ -217,7 +217,10 @@ Four methods of parsing the label are provided.
   * It allows slashes in file names and in text strings that are not quoted (e.g., 'N/A').
   * It allows the value of `END_OBJECT` and `END_GROUP` to be absent, as long as they are
     still properly paired with associated `OBJECT` and `GROUP` keywords.
-  * It allows time zone expressions (where were disallowed after the PDS2 standard).
+  * It allows time zone expressions, which were disallowed starting in Version 4 of the
+    standards.
+  * It allows blanks where leading zeros belong in dates and times, e.g., "2026- 7 - 4"
+    instead of "2026-07-04" and "12: 3: 4" instead of "12:03:04".
   * Commas can be missing between the elements of a sequence or set.
   * The final line terminator after `END` can be missing from a detached label.
 

--- a/pdsparser/_fast_dict.py
+++ b/pdsparser/_fast_dict.py
@@ -11,9 +11,12 @@ from .utils import _based_int, _is_identifier, _format_float, _unique_key, _unwr
 
 _UNITS = re.compile(r' *(<.*?>)')
 _BASED_INT = re.compile(r'(\d+)#(\w+)#')
-_DATE = re.compile(r'"?(\d\d\d\d-\d\d(?:\d|-\d\d))"?')
-_TIME = re.compile(r'"?(\d\d:\d\d(?:|\:\d\d(?:|.\d*))Z?)"?')
-_DATE_TIME = re.compile(r'"?(\d\d\d\d-\d\d(?:\d|-\d\d)T\d\d:\d\d(?:|\:\d\d(|.\d*))Z?)"?')
+
+_DATE_REGEX = r'\d\d\d\d-(?:\d\d\d| \d\d|  \d|[ 01]\d-[ 0123]\d)'
+_TIME_REGEX = r'[ \d]?\d:[ \d]\d(?:|\:[ \d]\d(?:|.\d*))Z?'
+_DATE = re.compile(rf'"?({_DATE_REGEX})"?')
+_TIME = re.compile(rf'"?({_TIME_REGEX})"?')
+_DATE_TIME = re.compile(rf'"?({_DATE_REGEX}T{_TIME_REGEX})"?')
 
 
 def _clean_lines(lines):
@@ -102,7 +105,7 @@ def _evaluate(value, recno, name):
     is_pointer = name.startswith('^')
 
     if match := _DATE_TIME.fullmatch(source):
-        day, sec = julian.day_sec_from_iso(match.group(1))
+        day, sec = julian.day_sec_from_iso(match.group(1).replace(' ', '0'))
         order = 'YDT' if len(value.split('-')) == 2 else 'YMDT'
         hour, minute, second = julian.hms_from_sec(sec)
         isec = int(second // 1.)
@@ -119,7 +122,7 @@ def _evaluate(value, recno, name):
         return (value, info)
 
     if match := _DATE.fullmatch(source):
-        day = julian.day_from_iso(match.group(1))
+        day = julian.day_from_iso(match.group(1).replace(' ', '0'))
         order = 'YD' if len(value.split('-')) == 2 else 'YMD'
         value = dt.date(*julian.ymd_from_day(day))
         info['day'] = day
@@ -129,7 +132,10 @@ def _evaluate(value, recno, name):
         return (value, info)
 
     if match := _TIME.fullmatch(source):
-        sec = julian.sec_from_iso(match.group(1).rstrip('Z'))
+        text = match.group(1).rstrip('Z').replace(' ', '0')
+        if text[1] == ':':
+            text = '0' + text
+        sec = julian.sec_from_iso(text)
         info['sec'] = sec
         hour, minute, second = julian.hms_from_sec(sec)
         isec = int(second // 1.)

--- a/tests/test_PDS3_GRAMMAR.py
+++ b/tests/test_PDS3_GRAMMAR.py
@@ -273,11 +273,11 @@ class Test_SimpleTime(unittest.TestCase):
                     strval='12:34:06.123456', test=2, super_=False)
         self.assertEqual(obj.type_, 'utc_time')
 
-        obj = _pass(self, _HmsTime, ' 2:34', dt.time( 2, 34), '02:34:00', test=2,
+        obj = _pass(self, _HmsTime, ' 2:34', dt.time(2, 34), '02:34:00', test=2,
                     super_=False)
         self.assertEqual(obj.type_, 'local_time')
 
-        obj = _pass(self, _UtcTime, ' 2:34Z', dt.time( 2, 34), '02:34:00', test=2,
+        obj = _pass(self, _UtcTime, ' 2:34Z', dt.time(2, 34), '02:34:00', test=2,
                     super_=False)
         self.assertEqual(obj.type_, 'utc_time')
 
@@ -289,7 +289,7 @@ class Test_SimpleTime(unittest.TestCase):
                     super_=False)
         self.assertEqual(obj.type_, 'utc_time')
 
-        _pass(self, _HmsTime, '" 2:34:56"', dt.time( 2, 34, 56), test=2, super_=False)
+        _pass(self, _HmsTime, '" 2:34:56"', dt.time(2, 34, 56), test=2, super_=False)
         _pass(self, _HmsTime, '"12: 4:56"', dt.time(12,  4, 56), test=2, super_=False)
         _pass(self, _HmsTime, '"12:34: 6"', dt.time(12, 34,  6), test=2, super_=False)
         _pass(self, _HmsTime, '"12:34: 6.5"', dt.time(12, 34,  6, 500000),
@@ -417,12 +417,12 @@ class Test_Time(unittest.TestCase):
         _fail(self, _Time, '12:34 +2:30', test=1)
         _fail(self, _Time, '12:34 +02:30', test=1)
 
-        _pass(self, _Time, ' 2:34:56', dt.time( 2, 34, 56), '02:34:56', test=2)
+        _pass(self, _Time, ' 2:34:56', dt.time(2, 34, 56), '02:34:56', test=2)
         _pass(self, _Time, '12: 4:56', dt.time(12,  4, 56), '12:04:56', test=2)
         _pass(self, _Time, '12:34: 6', dt.time(12, 34,  6), '12:34:06', test=2)
-        _pass(self, _Time, ' 2: 4: 6Z', dt.time( 2,  4,  6), '02:04:06', test=2)
+        _pass(self, _Time, ' 2: 4: 6Z', dt.time(2,  4,  6), '02:04:06', test=2)
 
-        _pass(self, _Time, ' 2:34:56.123456', dt.time( 2, 34, 56, 123456),
+        _pass(self, _Time, ' 2:34:56.123456', dt.time(2, 34, 56, 123456),
               '02:34:56.123456', test=2)
         _pass(self, _Time, '12: 4:56.123456', dt.time(12,  4, 56, 123456),
               '12:04:56.123456', test=2)

--- a/tests/test_PDS3_GRAMMAR.py
+++ b/tests/test_PDS3_GRAMMAR.py
@@ -254,7 +254,8 @@ class Test_SimpleTime(unittest.TestCase):
 
         _pass(self, _HmsTime, '"01:01:01"', dt.time(1, 1, 1))
 
-        _fail(self, _HmsTime, '2:34')
+        _fail(self, _HmsTime, '2:34', test=1)
+        _pass(self, _HmsTime, '2:34', dt.time(2, 34), '02:34:00', test=2, super_=False)
         _fail(self, _HmsTime, '12:3')
         _fail(self, _HmsTime, '123:34')
         _fail(self, _HmsTime, '123 :34')
@@ -263,31 +264,66 @@ class Test_SimpleTime(unittest.TestCase):
         _fail(self, _UtcTime, '12:34', super_=False)
         _fail(self, _UtcTime, '12:34 Z')
 
+        # Blanks in place of zeros
+        obj = _pass(self, _UtcTime, '12: 4:56Z', dt.time(12,  4, 56), '12:04:56', test=2,
+                    super_=False)
+        self.assertEqual(obj.type_, 'utc_time')
+
+        obj = _pass(self, _UtcTime, '12:34: 6.123456Z', dt.time(12, 34, 6, 123456),
+                    strval='12:34:06.123456', test=2, super_=False)
+        self.assertEqual(obj.type_, 'utc_time')
+
+        obj = _pass(self, _HmsTime, ' 2:34', dt.time( 2, 34), '02:34:00', test=2,
+                    super_=False)
+        self.assertEqual(obj.type_, 'local_time')
+
+        obj = _pass(self, _UtcTime, ' 2:34Z', dt.time( 2, 34), '02:34:00', test=2,
+                    super_=False)
+        self.assertEqual(obj.type_, 'utc_time')
+
+        obj = _pass(self, _HmsTime, '12: 4', dt.time(12,  4), '12:04:00', test=2,
+                    super_=False)
+        self.assertEqual(obj.type_, 'local_time')
+
+        obj = _pass(self, _UtcTime, '12: 4Z', dt.time(12, 4), '12:04:00', test=2,
+                    super_=False)
+        self.assertEqual(obj.type_, 'utc_time')
+
+        _pass(self, _HmsTime, '" 2:34:56"', dt.time( 2, 34, 56), test=2, super_=False)
+        _pass(self, _HmsTime, '"12: 4:56"', dt.time(12,  4, 56), test=2, super_=False)
+        _pass(self, _HmsTime, '"12:34: 6"', dt.time(12, 34,  6), test=2, super_=False)
+        _pass(self, _HmsTime, '"12:34: 6.5"', dt.time(12, 34,  6, 500000),
+              strval='12:34:06.500', test=2, super_=False)
+
 
 class Test_TimeZone(unittest.TestCase):
 
     def runTest(self):
 
-        _pass(self, _TimeZone, '+2:30', tz(2*60 + 30), '+02:30', dt.timezone)
-        _pass(self, _TimeZone, '+0:30', tz(30), '+00:30')
-        _pass(self, _TimeZone, '-0:30', tz(-30), '-00:30')
+        _pass(self, _TimeZone, '+02:30', tz(2*60 + 30), '+02:30', dt.timezone)
         _pass(self, _TimeZone, '+00:30', tz(30), '+00:30')
         _pass(self, _TimeZone, '-00:30', tz(-30), '-00:30')
-        _pass(self, _TimeZone, '-0', tz(0), '+00:00')
-        _pass(self, _TimeZone, '-00', tz(0), '+00:00')
-        _pass(self, _TimeZone, '-1', tz(-60), '-01:00')
-        _pass(self, _TimeZone, '-01', tz(-60), '-01:00')
-        _pass(self, _TimeZone, '+0', tz(0))
-        _pass(self, _TimeZone, '+00', tz(0))
-        _pass(self, _TimeZone, '+1', tz(60))
-        _pass(self, _TimeZone, '+01', tz(60))
-        _pass(self, _TimeZone, '+23:59', tz(23*60 + 59), '+23:59')
-        _pass(self, _TimeZone, '-23:59', tz(-23*60 - 59), '-23:59')
+        _pass(self, _TimeZone, '+00:30', tz(30), '+00:30')
+        _pass(self, _TimeZone, '-00:30', tz(-30), '-00:30')
+        _pass(self, _TimeZone, '+14:45', tz(14*60 + 45), '+14:45')
+        _pass(self, _TimeZone, '-12:45', tz(-12*60 - 45), '-12:45')
+        _pass(self, _TimeZone, '-00', tz(0), '+00')
+        _pass(self, _TimeZone, '+00', tz(0), '+00')
+        _pass(self, _TimeZone, '-01', tz(-60), '-01')
+        _pass(self, _TimeZone, '+01', tz(60), '+01')
+        _pass(self, _TimeZone, '-1:15', tz(-75), '-01:15')
+        _pass(self, _TimeZone, '-0', tz(0), '+00')
+        _pass(self, _TimeZone, '-1', tz(-60), '-01')
+        _pass(self, _TimeZone, '+0', tz(0), '+00')
+        _pass(self, _TimeZone, '+1', tz(60), '+01')
 
         _fail(self, _TimeZone, '0:30')
         _fail(self, _TimeZone, '-000')
         _fail(self, _TimeZone, ' -0:30')
-        _fail(self, _TimeZone, '- 0:30')
+        _fail(self, _TimeZone, '- 0:30', test=1)
+        _pass(self, _TimeZone, '- 0:30', tz(-30), '-00:30', test=2)
+        _fail(self, _TimeZone, '-01: 0', test=1)
+        _pass(self, _TimeZone, '-01: 0', tz(-60), '-01:00', test=2)
         _fail(self, _TimeZone, '-0 :30')
         _fail(self, _TimeZone, '-0: 30')
         _fail(self, _TimeZone, '-24')
@@ -301,16 +337,16 @@ class Test_ZonedTime(unittest.TestCase):
     def runTest(self):
 
         obj = _pass(self, _ZonedTime, '12:34+2', dt.time(12, 34, tzinfo=tz(2*60)),
-                    '12:34:00+02:00', dt.time, test=2, super_=False)
+                    '12:34:00+02', super_=False)
         self.assertEqual(obj.type_, 'zoned_time')
         self.assertEqual(obj.sec, 3600*12 + 34*60 - 3600*2)
-        self.assertEqual(obj.fmt, '12:34:00+02:00')
-        self.assertEqual(str(obj), '12:34:00+02:00')
-        self.assertEqual(repr(obj), '_ZonedTime(12:34:00+02:00)')
+        self.assertEqual(obj.fmt, '12:34:00+02')
+        self.assertEqual(str(obj), '12:34:00+02')
+        self.assertEqual(repr(obj), '_ZonedTime(12:34:00+02)')
         self.assertEqual(obj.source, '12:34+2')
 
         obj = _pass(self, _ZonedTime, '12:34+2:30', dt.time(12, 34, tzinfo=tz(2*60 + 30)),
-                    '12:34:00+02:30', dt.time, test=2, super_=False)
+                    '12:34:00+02:30', super_=False)
         self.assertEqual(obj.type_, 'zoned_time')
         self.assertEqual(obj.sec, 3600*12 + 34*60 - 3600*2 - 30*60)
         self.assertEqual(obj.fmt, '12:34:00+02:30')
@@ -319,14 +355,16 @@ class Test_ZonedTime(unittest.TestCase):
         self.assertEqual(obj.source, '12:34+2:30')
 
         _pass(self, _ZonedTime, '"12:34-02"', dt.time(12, 34, tzinfo=tz(-2*60)),
-              '12:34:00-02:00', dt.time, test=2, super_=False)
+              '12:34:00-02', super_=False)
         _pass(self, _ZonedTime, '"12:34-02:45"', dt.time(12, 34, tzinfo=tz(-2*60 - 45)),
-              '12:34:00-02:45', dt.time, test=2, super_=False)
+              '12:34:00-02:45', super_=False)
 
-        _fail(self, _ZonedTime, '12:34 +2:30',)
-        _fail(self, _ZonedTime, '12:34 +02:30',)
-        _fail(self, _ZonedTime, '12:34 -2',)
-        _fail(self, _ZonedTime, '12:34- 2',)
+        _fail(self, _ZonedTime, '12:34 +2:30')
+        _fail(self, _ZonedTime, '12:34 +02:30')
+        _fail(self, _ZonedTime, '12:34 -2')
+        _fail(self, _ZonedTime, '12:34- 2', test=1)
+        _pass(self, _ZonedTime, '12:34- 2', dt.time(12, 34, tzinfo=tz(-2*60)),
+              '12:34:00-02', test=2)
 
 
 class Test_Time(unittest.TestCase):
@@ -379,6 +417,18 @@ class Test_Time(unittest.TestCase):
         _fail(self, _Time, '12:34 +2:30', test=1)
         _fail(self, _Time, '12:34 +02:30', test=1)
 
+        _pass(self, _Time, ' 2:34:56', dt.time( 2, 34, 56), '02:34:56', test=2)
+        _pass(self, _Time, '12: 4:56', dt.time(12,  4, 56), '12:04:56', test=2)
+        _pass(self, _Time, '12:34: 6', dt.time(12, 34,  6), '12:34:06', test=2)
+        _pass(self, _Time, ' 2: 4: 6Z', dt.time( 2,  4,  6), '02:04:06', test=2)
+
+        _pass(self, _Time, ' 2:34:56.123456', dt.time( 2, 34, 56, 123456),
+              '02:34:56.123456', test=2)
+        _pass(self, _Time, '12: 4:56.123456', dt.time(12,  4, 56, 123456),
+              '12:04:56.123456', test=2)
+        _pass(self, _Time, '12:34: 6.123456', dt.time(12, 34,  6, 123456),
+              '12:34:06.123456', test=2)
+
 
 class Test_Date(unittest.TestCase):
 
@@ -398,12 +448,20 @@ class Test_Date(unittest.TestCase):
 
         _pass(self, _Date, '2000-12-01', dt.date(2000, 12, 1))
         _pass(self, _Date, '2000-12-31', dt.date(2000, 12, 31))
+        _pass(self, _Date, '2000-366', dt.date(2000, 12, 31))
 
         _fail(self, _Date, '3000-01-01')
         _fail(self, _Date, '2000-00-01')
         _fail(self, _Date, '2000-13-01')
         _fail(self, _Date, '2000-01-00')
         _fail(self, _Date, '2000-01-32')
+
+        _fail(self, _Date, '2000- 1-01', test=1)
+        _fail(self, _Date, '2000-01- 1', test=1)
+        _pass(self, _Date, '2000- 1-01', dt.date(2000, 1, 1), '2000-01-01', test=2,
+              super_=False)
+        _pass(self, _Date, '2000-01- 1', dt.date(2000, 1, 1), '2000-01-01', test=2,
+              super_=False)
 
 
 class Test_DateTime(unittest.TestCase):
@@ -425,24 +483,32 @@ class Test_DateTime(unittest.TestCase):
         self.assertEqual(str(obj), '2000-003T12:34:00')
         self.assertEqual(repr(obj), '_DateTime(2000-003T12:34:00)')
 
-        obj = _pass(self, _DateTime, '2000-01-01T01:23+4', dt.datetime(2000, 1, 1, 1, 23,
-                                                                       tzinfo=tz(4*60)),
-                    '2000-01-01T01:23:00+04:00', test=2)
+        obj = _pass(self, _DateTime, '2000-01-01T01:23+4',
+                    dt.datetime(2000, 1, 1, 1, 23, tzinfo=tz(4*60)),
+                    '2000-01-01T01:23:00+04', test=2)
         self.assertEqual(obj.day, -1)
         self.assertEqual(obj.sec, 60 * (23 + 60) - 4 * 3600 + 86400)
-        self.assertEqual(str(obj), '2000-01-01T01:23:00+04:00')
-        self.assertEqual(repr(obj), '_DateTime(2000-01-01T01:23:00+04:00)')
+        self.assertEqual(str(obj), '2000-01-01T01:23:00+04')
+        self.assertEqual(repr(obj), '_DateTime(2000-01-01T01:23:00+04)')
+
+        obj = _pass(self, _DateTime, '2000-01-01T23:46-4: 0',
+                    dt.datetime(2000, 1, 1, 23, 46, tzinfo=tz(-4*60)),
+                    '2000-01-01T23:46:00-04:00', test=2)
+        self.assertEqual(obj.day, 1)
+        self.assertEqual(obj.sec, 60 * (46 + 60 * 23) - 20 * 3600)
 
         _pass(self, _DateTime, '2000-01-01T12:34Z', dt.datetime(2000, 1, 1, 12, 34),
               '2000-01-01T12:34:00')
         _pass(self, _DateTime, '2000-01-01T12:34:56Z',
               dt.datetime(2000, 1, 1, 12, 34, 56), '2000-01-01T12:34:56')
-        _pass(self, _DateTime, '2000-01-01T01:23+4', dt.datetime(2000, 1, 1, 1, 23,
-                                                                 tzinfo=tz(4*60)),
-              '2000-01-01T01:23:00+04:00', test=2)
-        _pass(self, _DateTime, '2000-01-01T12:34:56+7:08',
-              dt.datetime(2000, 1, 1, 12, 34, 56, tzinfo=tz(7*60+8)),
-              '2000-01-01T12:34:56+07:08', test=2)
+        _fail(self, _DateTime, '2000-01-01T01:23+4', test=1)
+        _pass(self, _DateTime, '2000-01-01T01:23+4',
+              dt.datetime(2000, 1, 1, 1, 23, tzinfo=tz(4*60)),
+              '2000-01-01T01:23:00+04', test=2)
+        _fail(self, _DateTime, '2000-01-01T12:34:56+7:15', test=1)
+        _pass(self, _DateTime, '2000-01-01T12:34:56+7:15',
+              dt.datetime(2000, 1, 1, 12, 34, 56, tzinfo=tz(7*60+15)),
+              '2000-01-01T12:34:56+07:15', test=2)
 
         _pass(self, _DateTime, '2004-366T04:38:16.12345678Z',
               dt.datetime(2004, 12, 31, 4, 38, 16, 123457),
@@ -453,7 +519,40 @@ class Test_DateTime(unittest.TestCase):
         _fail(self, _DateTime, '2000-01-01T12:34 Z')
 
         _fail(self, _DateTime, '2000-01-01T01:23+4', test=1)
-        _fail(self, _DateTime, '2000-01-01T12:34:56+7:08', test=1)
+        _pass(self, _DateTime, '2000-01-01T01:23+4',
+              dt.datetime(2000, 1, 1, 1, 23, tzinfo=tz(4*60)),
+              '2000-01-01T01:23:00+04', test=2)
+        _fail(self, _DateTime, '2000-01-01T12:34:56+7:15', test=1)
+        _pass(self, _DateTime, '2000-01-01T12:34:56+7:15',
+              dt.datetime(2000, 1, 1, 12, 34, 56, tzinfo=tz(7*60+15)),
+              strval='2000-01-01T12:34:56+07:15', test=2)
+        _fail(self, _DateTime, '2000-01-01T12:34:56+07:08')
+
+        _fail(self, _DateTime, '2000- 1-01T12:34', test=1)
+        _fail(self, _DateTime, '2000-01- 1T12:34', test=1)
+        _fail(self, _DateTime, '2000-01- 2T12:34Z', test=1)
+        _fail(self, _DateTime, '2000-01-01T 1:23+4', test=1)
+        _fail(self, _DateTime, '2000-01-01T12: 4:56+7:15', test=1)
+        _fail(self, _DateTime, '2000-01-01T12:34: 6+07:08', test=1)
+
+        _pass(self, _DateTime, '2004- 1-22T12:34',
+              dt.datetime(2004,  1, 22, 12, 34), '2004-01-22T12:34:00', test=2)
+        _pass(self, _DateTime, '2004-11- 2T12:34',
+              dt.datetime(2004, 11,  2, 12, 34), '2004-11-02T12:34:00', test=2)
+        _pass(self, _DateTime, '2004-11-22T 2:34Z',
+              dt.datetime(2004, 11, 22,  2, 34), '2004-11-22T02:34:00', test=2)
+        _pass(self, _DateTime, '2004-11-22T12:04',
+              dt.datetime(2004, 11, 22, 12,  4), '2004-11-22T12:04:00', test=2)
+        _pass(self, _DateTime, '2004-11-22T12:34: 6Z',
+              dt.datetime(2004, 11, 22, 12, 34, 6), '2004-11-22T12:34:06', test=2)
+        _pass(self, _DateTime, '2004-11-22T12:34:56+7',
+              dt.datetime(2004, 11, 22, 12, 34, 56, tzinfo=tz(7*60)),
+              '2004-11-22T12:34:56+07', test=2)
+        _pass(self, _DateTime, '2004-11-22T12:34:56+07: 0',
+              dt.datetime(2004, 11, 22, 12, 34, 56, tzinfo=tz(7*60)),
+              '2004-11-22T12:34:56+07:00', test=2)
+        _pass(self, _DateTime, '2004-11-22T12:34: 6Z',
+              dt.datetime(2004, 11, 22, 12, 34, 6), '2004-11-22T12:34:06', test=2)
 
 
 class Test_Text(unittest.TestCase):

--- a/tests/test_labels.py
+++ b/tests/test_labels.py
@@ -504,6 +504,51 @@ class Test_labels(unittest.TestCase):
         d1 = Pds3Label(content, method='loose')
         self.assertEqual(d1.dict, {'VALUE': [[1, 2], [3, "four"]]})
 
+        # Times with embedded blanks where zeros belong
+        for method in ('fast', 'loose'):
+            for q in ('', '"'):
+                for date1 in ('2001- 2- 3', '2004-05- 6', '2007- 8-09',
+                              '2010-  3', '2014- 56'):
+                    date2 = date1.replace(' ', '0')
+                    d1 = Pds3Label(f'DATE = {q}{date1}{q}\n', method=method)
+                    d2 = Pds3Label(f'DATE = {q}{date2}{q}\n', method=method)
+                    self.assertEqual(d1.dict, d2.dict)
+                    self.assertEqual(d1.dict['DATE_fmt'], date2)
+
+                    for hh in (' 6', '07'):
+                        for mm in ('08', ' 9'):
+                            time1 = f'{hh}:{mm}'
+                            time2 = time1.replace(' ', '0')
+                            if time2[1] == ':':
+                                time2 = '0' + time2
+                            d1 = Pds3Label(f'TIME = {q}{time1}{q}\n', method=method)
+                            d2 = Pds3Label(f'TIME = {q}{time2}{q}\n', method=method)
+                            self.assertEqual(d1.dict, d2.dict)
+                            self.assertEqual(d1.dict['TIME_fmt'], time2 + ':00')
+
+                            dt1 = date1 + 'T' + time1
+                            dt2 = date2 + 'T' + time2
+                            d1 = Pds3Label(f'DATE = {q}{dt1}{q}\n', method=method)
+                            d2 = Pds3Label(f'DATE = {q}{dt2}{q}\n', method=method)
+                            self.assertEqual(d1.dict, d2.dict)
+                            self.assertEqual(d1.dict['DATE_fmt'], dt2 + ':00')
+
+                            for ss in (' 1', '02', ' 5.678'):
+                                time1 = f'{hh}:{mm}:{ss}'
+                                time2 = time1.replace(' ', '0')
+                                d1 = Pds3Label(f'TIME = {q}{time1}{q}\n', method=method)
+                                d2 = Pds3Label(f'TIME = {q}{time2}{q}\n', method=method)
+                                self.assertEqual(d1.dict, d2.dict)
+                                self.assertEqual(d1.dict['TIME_fmt'], time2)
+
+                                dt1 = date1 + 'T' + time1
+                                dt2 = date2 + 'T' + time2
+                                d1 = Pds3Label(f'DATE = {q}{dt1}{q}\n', method=method)
+                                d2 = Pds3Label(f'DATE = {q}{dt2}{q}\n', method=method)
+                                self.assertEqual(d1.dict, d2.dict)
+                                self.assertEqual(d1.dict['DATE_fmt'], dt2)
+
+
     def test_as_dict(self):
 
         self.maxDiff = MAXDIFF

--- a/tests/test_labels.py
+++ b/tests/test_labels.py
@@ -548,6 +548,21 @@ class Test_labels(unittest.TestCase):
                                 self.assertEqual(d1.dict, d2.dict)
                                 self.assertEqual(d1.dict['DATE_fmt'], dt2)
 
+        method = 'loose'
+        for q in ('', '"'):
+            for tz in ('-2', '+ 3', '-4: 0', '+05: 0'):
+               for hms in (' 2:34:56', ' 2: 3: 4', '12:34: 5.67'):
+                    time1 = f'{hms}{tz}'
+                    time2 = time1.replace(' ', '0')
+                    d1 = Pds3Label(f'TIME = {q}{time1}{q}\n', method=method)
+                    d2 = Pds3Label(f'TIME = {q}{time2}{q}\n', method=method)
+                    self.assertEqual(d1.dict, d2.dict)
+
+                    dt1 = '2012-01-23T' + time1
+                    dt2 = '2012-01-23T' + time2
+                    d1 = Pds3Label(f'DATE = {q}{dt1}{q}\n', method=method)
+                    d2 = Pds3Label(f'DATE = {q}{dt2}{q}\n', method=method)
+                    self.assertEqual(d1.dict, d2.dict)
 
     def test_as_dict(self):
 

--- a/tests/test_labels.py
+++ b/tests/test_labels.py
@@ -474,10 +474,10 @@ class Test_labels(unittest.TestCase):
         d1 = Pds3Label(content, method='loose', _details=True)
         self.assertEqual(d1.dict,
                          {'TEST': {'OBJECT': 'TEST',
-                           'OBJECT_detail': _Text('', 0, ['TEST']),
-                           'VALUE': 7,
-                           'VALUE_detail': _Integer('', 0, ['7']),
-                           'END_OBJECT': 'TEST'},
+                                   'OBJECT_detail': _Text('', 0, ['TEST']),
+                                   'VALUE': 7,
+                                   'VALUE_detail': _Integer('', 0, ['7']),
+                                   'END_OBJECT': 'TEST'},
                           'END': None,
                           'objects': ['TEST']})
 
@@ -551,7 +551,7 @@ class Test_labels(unittest.TestCase):
         method = 'loose'
         for q in ('', '"'):
             for tz in ('-2', '+ 3', '-4: 0', '+05: 0'):
-               for hms in (' 2:34:56', ' 2: 3: 4', '12:34: 5.67'):
+                for hms in (' 2:34:56', ' 2: 3: 4', '12:34: 5.67'):
                     time1 = f'{hms}{tz}'
                     time2 = time1.replace(' ', '0')
                     d1 = Pds3Label(f'TIME = {q}{time1}{q}\n', method=method)


### PR DESCRIPTION
As discussed, the "loose" and "fast" methods now allow blanks where leading zeros belong in any part of a date or time.

The "fast" option required just a few changed lines.

The "loose" option was trickier because that goes through the grammar, so changes there are more extensive. In the process, annoyingly, I had to clean up a bit of the time zone code. So the changes there are more extensive.

I added many new unit tests to support the changes. Everything passes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Loose parsing now accepts space-padded date/time components (e.g., `2026- 7 - 4`, `12: 3: 4`) and additional timezone/datetime variants with normalized output.

* **Documentation**
  * Updated README and module docs to clarify which formatting variations loose parsing permits.

* **Tests**
  * Expanded test suite to cover whitespace-tolerant date/time, timezone normalization, and equivalence between blank-containing and zero-normalized inputs.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/SETI/rms-pdsparser/pull/19)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->